### PR TITLE
Fix interop with other plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ HtmlWebpackExcludeAssetsPlugin.prototype.apply = function (compiler) {
       var excludeAssets = htmlPluginData.plugin.options.excludeAssets;
       // Skip if the plugin configuration didn't set `excludeAssets`
       if (!excludeAssets) {
-        return callback(null);
+        return callback(null, htmlPluginData);
       }
 
       if (excludeAssets.constructor !== Array) {
@@ -55,7 +55,7 @@ HtmlWebpackExcludeAssetsPlugin.prototype.processAssets = function (excludePatter
     }
   });
 
-  return { head: head, body: body };
+  return { head: head, body: body, plugin: pluginData.plugin, chunks: pluginData.chunks, outputName: pluginData.outputName };
 };
 
 module.exports = HtmlWebpackExcludeAssetsPlugin;


### PR DESCRIPTION
When using this plugin with other plugins attaching to the same hooks, the callback result will become the htmlPluginData object for the next plugin, so unmodified properties need to be copied or they will be lost.

I ran into this problem when using html-webpack-inline-source-plugin, which suffers from the same bug. Patching this in both plugins solved the issue.

See also [the corresponding issue on the other repo](https://github.com/DustinJackson/html-webpack-inline-source-plugin/pull/18). I'm not sure what these plugins are based on but I'm suspecting at some point someone blindly copied what the html-webpack-plugin unit tests are doing without consulting the actual implementation.