### PR TITLE
Update for webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,44 +1,64 @@
 'use strict';
 var assert = require('assert');
 
-function HtmlWebpackExcludeAssetsPlugin (options) {
+function HtmlWebpackExcludeAssetsPlugin(options) {
   assert.equal(options, undefined, 'The HtmlWebpackExcludeAssetsPlugin does not accept any options');
+  this.PluginName = 'HtmlWebpackExcludeAssetsPlugin';
 }
 
 HtmlWebpackExcludeAssetsPlugin.prototype.apply = function (compiler) {
   var self = this;
-
-  // Hook into the html-webpack-plugin processing
-  compiler.plugin('compilation', function (compilation) {
-    compilation.plugin('html-webpack-plugin-alter-asset-tags', function (htmlPluginData, callback) {
-      var excludeAssets = htmlPluginData.plugin.options.excludeAssets;
-      // Skip if the plugin configuration didn't set `excludeAssets`
-      if (!excludeAssets) {
-        if (callback) {
-          return callback(null, htmlPluginData);
-        } else {
-          return Promise.resolve(htmlPluginData);
-        }
-      }
-
-      if (excludeAssets.constructor !== Array) {
-        excludeAssets = [excludeAssets];
-      }
-
-      // Skip invalid RegExp patterns
-      var excludePatterns = excludeAssets.filter(function (excludePattern) {
-        return excludePattern.constructor === RegExp;
-      });
-
-      var result = self.processAssets(excludePatterns, htmlPluginData);
-      if (callback) {
-        callback(null, result);
-      } else {
-        return Promise.resolve(result);
-      }
-    });
-  });
+  
+  if ('hooks' in compiler) {
+    // v4 approach:
+    compiler.hooks.compilation.tap(this.PluginName, this.applyCompilation.bind(this));
+  } else {
+    // legacy approach:
+    // Hook into the html-webpack-plugin processing
+    compiler.plugin('compilation', this.applyCompilation.bind(this));
+  }
 };
+
+HtmlWebpackExcludeAssetsPlugin.prototype.applyCompilation = function applyCompilation(compilation) {
+  var self = this;
+  if ('hooks' in compilation) {
+    // If our target hook is not present, throw a descriptive error
+    if(!compilation.hooks.htmlWebpackPluginAlterAssetTags) {
+      throw new Error('The expected HtmlWebpackPlugin hook was not found! Ensure HtmlWebpackPlugin is installed and' +
+        ' was initialized before this plugin.');
+    }
+    compilation.hooks.htmlWebpackPluginAlterAssetTags.tapAsync(this.PluginName, registerCb);
+  } else {
+    compilation.plugin('html-webpack-plugin-alter-asset-tags', registerCb);
+  }
+  function registerCb(htmlPluginData, callback) {
+    var excludeAssets = htmlPluginData.plugin.options.excludeAssets;
+    // Skip if the plugin configuration didn't set `excludeAssets`
+    if (!excludeAssets) {
+      if (callback) {
+        return callback(null, htmlPluginData);
+      } else {
+        return Promise.resolve(htmlPluginData);
+      }
+    }
+
+    if (excludeAssets.constructor !== Array) {
+      excludeAssets = [excludeAssets];
+    }
+
+    // Skip invalid RegExp patterns
+    var excludePatterns = excludeAssets.filter(function (excludePattern) {
+      return excludePattern.constructor === RegExp;
+    });
+
+    var result = self.processAssets(excludePatterns, htmlPluginData);
+    if (callback) {
+      callback(null, result);
+    } else {
+      return Promise.resolve(result);
+    }
+  }
+}
 
 HtmlWebpackExcludeAssetsPlugin.prototype.isExcluded = function (excludePatterns, assetPath) {
   return excludePatterns.filter(function (excludePattern) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-webpack-exclude-assets-plugin",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Add the ability to exclude assets based on RegExp patterns",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
I found this plugin not working with webpack 4, so I updated it. Uses the new `hooks` api from webpack. It should still be compatible with webpack <4.